### PR TITLE
La force de la potion n'était pas dite dans Druide.preparerPotion

### DIFF
--- a/src/personnages/Druide.java
+++ b/src/personnages/Druide.java
@@ -22,7 +22,7 @@ public class Druide {
 	}
 
 	public void parler(String texte) {
-		System.out.println(prendreParole() + "« " + texte + "»");
+		System.out.println(prendreParole() + "« " + texte + " »");
 	}
 
 	private String prendreParole() {
@@ -34,9 +34,9 @@ public class Druide {
 		int forcePotion = random.nextInt(effetPotionMax - effetPotionMin) + effetPotionMin;
 
 		if (forcePotion > 7) {
-			parler("J'ai préparé une super potion de force");
+			parler("J'ai préparé une super potion de force " + forcePotion);
 		} else {
-			parler("Je n'ai pas trouvé tous les ingrédients, ma potion est seulement de force");
+			parler("Je n'ai pas trouvé tous les ingrédients, ma potion est seulement de force " + forcePotion);
 		}
 
 		return forcePotion;


### PR DESCRIPTION
La force de la potion n'était pas dite dans Druide.preparerPotion

Changement apporté:
```java
parler("J'ai préparé une super potion de force " + forcePotion);
```

![macron-rC3A9action](https://github.com/user-attachments/assets/653d9ae0-3473-4528-9817-0df727f2a8d0)
